### PR TITLE
docs: move.vim is a full IDE plugin rather than a utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Directory tracking developer tools and infrastructure projects within Sui ecosys
 - ⚠️ [VSCode Sui Move Analyzer by Movebit](IDE/vscode_movebit_sui_move_analyzer.md) - A fork of VSCode Move by Mysten Labs.
 - [IntelliJ Sui Move Language Plugin](IDE/intellij_sui_move_language.md) - IntelliJ-based plugin for Move on Sui development.
 - [Emacs move-mode](IDE/emacs_movemode.md) - move-mode is an Emacs major-mode for editing smart contracts written in the Move programming language
+- [Move.vim](IDE/movevim.md) - Syntax highlighting for the Move smart contract programming language.
 
 ### IDE Utilities
 - [Prettier Move Plugin](IDE/prettier_move_plugin.md) - a Move language plugin for the Prettier code formatter
 - [Sui Extension](IDE/vscode_sui_extension.md) - The Sui extension provides seamless support for compiling, deploying, and testing Sui smart contracts directly within VS Code.
 - ⚠️ [Sui Simulator](IDE/vscode_sui_simulator.md) - VSCode Extension to streamline Sui development workflow with intuitive UI.
-- [Move.vim](IDE/movevim.md) - Syntax highlighting for the Move smart contract programming language.
 - [Tree Sitter Move](IDE/tree_sitter_move.md) - Tree Sitter for Move.
 
 ## Client SDKs & Libraries


### PR DESCRIPTION
Moving `move.vim` into the same category as the other IDEs (VSCode, Intellij, Emacs), rather than an IDE utility.