### PR TITLE
[AI]: add Atoma + Eliza Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ Sui is the first blockchain built for internet scale, enabling fast, scalable, a
 
 - [RagPool](https://ragpool.digkas.nl/) - RAG based chat with docs.
 - [Cookbook](https://docsbot-demo-git-sui-cookbookdev.vercel.app/) - Gemini-based RAG built for docs.
+- [Atoma](https://atoma.network/) - Developer-focused infrastructure for private, verifiable, and fully customized AI experiences.
+- [Eliza](https://github.com/elizaOS/eliza) - Autonomous agents for everyone.
 
 ## Walrus
 


### PR DESCRIPTION
# Atoma + Eliza

## Tooling Category

- [ x ] AI
- [ ] dApp Development
- [ ] Explorer
- [ ] IDE
- [ ] Indexer
- [ ] Oracle
- [ ] SDK
- [ ] Walrus
- [ ] Infrastructure as Code

## Homepage or Repo or Download Link

* https://atoma.network/
* https://github.com/elizaOS/eliza

## Description

Atoma has been in the Sui ecosystem enabling AI for Builders[1](https://blog.sui.io/atoma-ai-artificial-intelligence-blockchain/).

Eliza is a popular agent development kit with Sui + Atoma integration. [2](https://github.com/elizaOS/eliza/tree/v0.1.8/packages/plugin-sui)[3](https://github.com/elizaOS/eliza/pull/2082)


## Features

* Atoma: On-Chain, Verifiable AI Compute
* Eliza: Agent Framework with a great plugin ecosystem (including Sui)

## Documentation or Tutorial

* Atoma Network Tutorials: [Learn about Atoma Proxy](https://www.youtube.com/watch?v=eZLvswmoN_M), [Setup Atoma Node](https://www.youtube.com/watch?v=I0t0Q01ageM) 
* ElizaOS: [General Plugin Guide/Docs](https://www.youtube.com/watch?v=eZLvswmoN_M), [Sui Plugin README](https://github.com/elizaOS/eliza/blob/develop/packages/plugin-sui/README.md)

## Latest Version Number of Sui Tested On

```
$ sui --version
sui 1.39.4-2b9ad60878db
```