### PR TITLE
Add pattonkan/sui-go SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Sui is the first blockchain built for internet scale, enabling fast, scalable, a
   - [GitHub](https://github.com/FrankC01/pysui?tab=readme-ov-file) - [Documentation](https://pysui.readthedocs.io/en/latest/index.html) - [Pypi](https://pypi.org/project/pysui/) - [Discord](https://discord.gg/uCGYfY4Ph4) - [Further Information](details/sdk_pysui.md)
 - Sui Go SDK (SuiVision) - Golang SDK to interact with Sui blockchain.
   - [GitHub](https://github.com/block-vision/sui-go-sdk) - [API Documentation](https://pkg.go.dev/github.com/block-vision/sui-go-sdk) - [Examples](https://github.com/block-vision/sui-go-sdk?tab=readme-ov-file#examples) - [Further Information](details/sdk_sui_go.md)
+- Sui Go SDK (Pattonkan) - Golang SDK to interact with Sui blockchain. Support PTB and devInspect.
+  - [Github](https://github.com/pattonkan/sui-go) - [API Documentation](https://pkg.go.dev/github.com/pattonkan/sui-go) - [Examples](https://github.com/pattonkan/sui-go/tree/main/examples) - [Further Information](details/go-sui.md)
 - Sui Dart SDK - Dart SDK to interact with Sui blockchain.
   - [GitHub](https://github.com/mofalabs/sui) - [API documentation](https://pub.dev/documentation/sui/latest/) - [Further Information](details/sdk_sui_dart.md)
 - Sui Kotlin SDK - Kotlin Multiplatform (KMP) SDK for integrating with the Sui blockchain.

--- a/details/go-sui.md
+++ b/details/go-sui.md
@@ -1,0 +1,19 @@
+# Sui Go SDK (by SuiVision)
+
+## Tooling Category
+
+- [ ] dApp Development
+- [ ] Explorer
+- [ ] IDE
+- [ ] Indexer
+- [ ] Oracle
+- [x] SDK
+
+## Description
+
+The go-sui tool from Pattonkan facilitates basic Sui interactions. Additionally, this SDK features cleaner type definitions, supports devInspect transactions, and includes PTB by default.
+
+## Features
+
+- [Features](https://github.com/pattonkan/sui-go/tree/main/examples)
+- ⚠️ GraphQL is not supported yet.


### PR DESCRIPTION
The BlockVision Sui Go SDK is one of Sui's most popular Go SDKs. 
I want to thank BlockVision for its contribution to the community. However, it is quite outdated and lacks important features such as devInspect and PTB. A go-sui, which is a better API, is not popular, which is the reason for this PR.

