### PR TITLE
Add sui-go-dapp 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Sui is the first blockchain built for internet scale, enabling fast, scalable, a
   - [Homepage](https://kit.suiware.io/) - [Documentation](https://github.com/suiware/kit/tree/main/packages/kit#readme) - [GitHub](https://github.com/suiware/kit)
 - React ZK Login Kit - Ready-to-use Component with Hook (sign-in + sign-transaction)
   - [GitHub](https://github.com/denyskozak/react-sui-zk-login-kit) - [YouTube Guide](https://www.youtube.com/watch?v=2qnjmKg3ugY)
+- [sui-go-dapp](https://github.com/pwh-pwh/sui-go-dapp) - This is a template project for building decentralized applications (dApps) on the Sui blockchain using the Fyne framework. It demonstrates how to create a cross-platform application (desktop, web, and mobile) that interacts with a Sui smart contract.
 
 #### zkLogin
 


### PR DESCRIPTION
This is a template project for building decentralized applications (dApps) on the Sui blockchain using the Fyne framework. 