### PR TITLE
Add sui-mcp-server — 53-tool MCP server for Sui

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
   - [GitHub](https://github.com/Talus-Network) - [Quick Start](https://docs.talus.network/getting-started/math-branching-quickstart)
 - [Atoma](https://atoma.network/) - Developer-focused infrastructure for private, verifiable, and fully customized AI experiences.
 - [Eliza](https://github.com/elizaOS/eliza) - Autonomous agents for everyone.
+- [sui-mcp-server](https://github.com/ExpertVagabond/sui-mcp-server) - 53-tool MCP server for AI agents — wallets, DeFi, Move contracts, staking, SuiNS, analytics.
 
 ## Infrastructure as Code
 


### PR DESCRIPTION
## Summary

Adds [sui-mcp-server](https://github.com/ExpertVagabond/sui-mcp-server) to the **AI** section — a 53-tool MCP server that gives AI agents full access to the Sui blockchain.

## Details

- **npm published**: [`sui-mcp-server`](https://www.npmjs.com/package/sui-mcp-server)
- **59 tests** passing
- **GraphQL dual-transport**: JSON-RPC + GraphQL for full API coverage
- **Verified on devnet, testnet, and mainnet**
- **Tool coverage**: wallets, DeFi (Cetus, DeepBook), Move contract interaction, staking/validators, SuiNS name resolution, coin metadata, analytics, and more

Built for the [Model Context Protocol](https://modelcontextprotocol.io/) standard — works with Claude, GPT, and any MCP-compatible AI agent.