### PR TITLE
Add zcash-ika: agent custody on Ika dWallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
 - [FlowX SDK](https://github.com/FlowX-Finance/sdk) - The official FlowX TypeScript SDK that allows developers to interact with FlowX protocols using the TypeScript programming language.
 - [7k Aggregator SDK](https://github.com/7k-ag/7k-sdk-ts) - The TypeScript SDK for interacting with 7k Aggregator protocol.
 - [Hop Aggregator SDK](https://docs.hop.ag/hop-sdk) - The TypeScript SDK for interacting with Hop Aggregator.
+- [zcash-ika](https://github.com/Frontier-Compute/zcash-ika) - Agent custody SDK on Ika. Sui Move spend policy + UTXO TX builder for Zcash/Bitcoin. DeepBook integration ready.
+
 
 ### Client Libraries
 


### PR DESCRIPTION
Split-key custody SDK using Ika's 2PC-MPC on Sui. Move policy contract for spend limits. Signs Zcash, Bitcoin, and EVM. npm: @frontiercompute/zcash-ika