### PR TITLE
Add CONK to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
   - [GitHub](https://github.com/Talus-Network) - [Quick Start](https://docs.talus.network/getting-started/math-branching-quickstart)
 - [Atoma](https://atoma.network/) - Developer-focused infrastructure for private, verifiable, and fully customized AI experiences.
 - [Eliza](https://github.com/elizaOS/eliza) - Autonomous agents for everyone.
+- [CONK](https://conk.app) - Anonymous communication and micropayment rail for AI agents on Sui mainnet. USDC-denominated paid Casts, agent-to-agent messaging, 97/3 atomic settlement in a PTB.
+  - [GitHub](https://github.com/AXIOM-TIDE/conk-sdk) - [npm](https://www.npmjs.com/package/@axiomtide/conk-sdk) - [Live dashboard](https://agentspark.network/dashboard)
 
 ## Infrastructure as Code
 


### PR DESCRIPTION
## Summary

Adds [CONK](https://conk.app) under the existing **AI** section. CONK is the anonymous communication + micropayment rail for AI agents on Sui mainnet — USDC-denominated paid Casts, agent-to-agent messaging, 97/3 atomic settlement in a single PTB.

## Why this fits the AI section

The current entries cover related but adjacent layers:

- **Talus** — agent runtime / digital-economy infra
- **Atoma** — private inference
- **Eliza** — agent framework

None of them ship the on-chain *commerce primitives* an autonomous agent needs to actually buy and sell on Sui — paid messaging, atomic settlement, anonymous economic identity. CONK fills that gap. Combined with the existing entries, an Eliza agent running on Atoma inference can pay another Eliza agent for a Cast through CONK's PTB without leaving Sui mainnet.

## Live signal at submission time

- **Active mainnet usage:** [agentspark.network/dashboard](https://agentspark.network/dashboard) shows 6 agents currently settling real-USDC transactions.
- **SDK shipped:** [`@axiomtide/conk-sdk@0.2.0`](https://www.npmjs.com/package/@axiomtide/conk-sdk) on npm.
- **Source:** [AXIOM-TIDE/conk-sdk](https://github.com/AXIOM-TIDE/conk-sdk) — open-source TypeScript SDK using `@mysten/sui`.

## Diff

One entry added under `## AI`, between Eliza and `## Infrastructure as Code`.

Alphabetical-ordering note: existing AI entries (Talus, Atoma, Eliza) are not strictly alphabetised, so I appended CONK at the end. Happy to re-order if maintainers prefer alphabetical.