### PR TITLE
Add QuantOracle to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
   - [GitHub](https://github.com/Talus-Network) - [Quick Start](https://docs.talus.network/getting-started/math-branching-quickstart)
 - [Atoma](https://atoma.network/) - Developer-focused infrastructure for private, verifiable, and fully customized AI experiences.
 - [Eliza](https://github.com/elizaOS/eliza) - Autonomous agents for everyone.
+- [QuantOracle](https://quantoracle.dev/) - Deterministic quant-finance tools (Black-Scholes, liquidation price, impermanent loss, VaR/risk analysis) that Sui AI agents call as tools — over MCP or a TypeScript tool-pack — so they compute instead of hallucinating the math.
+  - [GitHub](https://github.com/QuantOracledev/quantoracle) - [Sui Integration](https://quantoracle.dev/writing/sui-talus-quant-agent)
 
 ## Infrastructure as Code
 


### PR DESCRIPTION
## Tooling Category

- [x] AI

## Homepage or Repo or Download Link

- Homepage: https://quantoracle.dev/
- GitHub: https://github.com/QuantOracledev/quantoracle

## Description

QuantOracle is a deterministic quant-finance API that AI agents call as **tools** instead of computing the math in-context (where LLMs silently drift 5–30% on things like option Greeks or liquidation levels). Sui agents can use it two ways:

- **MCP** — a hosted server at `https://mcp.quantoracle.dev/mcp` exposes all tools to any MCP-capable Sui agent (Sui AI Agent Kit, Talus/Nexus offchain layer, etc.) with zero code.
- **TypeScript tool-pack** — `@quantoracle/sui-agent-kit` ships portable, framework-agnostic tool definitions for custom agents.

It pairs naturally with Sui DeFi agents — e.g. liquidation-price and impermanent-loss for Suilend/Cetus strategies.

## Features

- 73 deterministic calculators + a batch endpoint (options/derivatives, risk, portfolio, statistics, crypto/DeFi, FX/macro, TVM)
- Deterministic & citation-verified (Hull, Wilmott, Bailey & López de Prado) — same inputs always produce the same output, suitable for verifiable/auditable agent actions
- Free tier: 1,000 calls/IP/day, no API key
- Paid composites via [x402](https://www.x402.org/) micropayments (USDC on Base or Solana)

## Documentation or Tutorial

- Sui/Talus integration guide: https://quantoracle.dev/writing/sui-talus-quant-agent
- API docs: https://api.quantoracle.dev/docs

## Latest Version Number of Sui Tested On

N/A — QuantOracle is an off-chain, chain-agnostic HTTP/MCP service with no on-chain Sui component; it integrates with Sui agents at the tool-calling layer (MCP / TypeScript), so no Sui framework version is pinned.