### PR TITLE
Add PoR SDK (Client SDKs) and Sui x402 Facilitator (AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
   - [GitHub](https://github.com/OpenDive/Sui-Unity-SDK) - [Further Information](details/sdk_sui_unity_opendive.md)
 - Dubhe Client (Dubhe Engine) - Supports various platforms including browsers, Node.js, and game engine. It provides a simple interface to interact with your Sui Move contracts.
   - [GitHub](https://github.com/0xobelisk/dubhe/tree/main/packages/sui-client) - [Documentation](https://dubhe-docs.obelisk.build/)
+- PoR SDK (Proof of Real) - Gate any Sui app on verified-human (proof-of-personhood) credentials in a few lines.
+  - [npm](https://www.npmjs.com/package/por-sdk) - [Website](https://por-proof-of-real.netlify.app)
 
 ### DeFi SDKs
 - [NAVI Protocol SDK](https://github.com/naviprotocol/navi-sdk) - The NAVI TypeScript SDK Client provides tools for interacting with the Sui Blockchain networks, designed for handling transactions, accounts, and smart contracts efficiently.
@@ -244,6 +246,8 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
   - [GitHub](https://github.com/Talus-Network) - [Quick Start](https://docs.talus.network/getting-started/math-branching-quickstart)
 - [Atoma](https://atoma.network/) - Developer-focused infrastructure for private, verifiable, and fully customized AI experiences.
 - [Eliza](https://github.com/elizaOS/eliza) - Autonomous agents for everyone.
+- [Sui x402 Facilitator](https://sui-facilitator.onrender.com) - The first live, non-custodial x402 facilitator on Sui — agents pay for HTTP resources with on-chain settlement and zero protocol fees.
+  - [GitHub](https://github.com/DrVelvetFog/sui-x402-facilitator)
 
 ## Infrastructure as Code
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
 - Dubhe Client (Dubhe Engine) - Supports various platforms including browsers, Node.js, and game engine. It provides a simple interface to interact with your Sui Move contracts.
   - [GitHub](https://github.com/0xobelisk/dubhe/tree/main/packages/sui-client) - [Documentation](https://dubhe-docs.obelisk.build/)
 - PoR SDK (Proof of Real) - Gate any Sui app on verified-human (proof-of-personhood) credentials in a few lines.
-  - [npm](https://www.npmjs.com/package/por-sdk) - [Website](https://por-proof-of-real.netlify.app)
+  - [GitHub](https://github.com/DrVelvetFog/por-sdk) - [npm](https://www.npmjs.com/package/por-sdk) - [Website](https://por-proof-of-real.netlify.app)
 
 ### DeFi SDKs
 - [NAVI Protocol SDK](https://github.com/naviprotocol/navi-sdk) - The NAVI TypeScript SDK Client provides tools for interacting with the Sui Blockchain networks, designed for handling transactions, accounts, and smart contracts efficiently.


### PR DESCRIPTION
Adds two stable, documented Sui tools to the index.

**Client SDKs — PoR SDK (Proof of Real)**
A published npm SDK ([`por-sdk`](https://www.npmjs.com/package/por-sdk)) that lets a Sui app gate access on verified-human (proof-of-personhood) credentials in a few lines. Docs at the [project site](https://por-proof-of-real.netlify.app).

**AI — Sui x402 Facilitator**
An independent, non-custodial [x402](https://x402.org) facilitator on Sui — lets agents pay for HTTP resources with on-chain settlement and zero protocol fees. Public repo: [DrVelvetFog/sui-x402-facilitator](https://github.com/DrVelvetFog/sui-x402-facilitator), live at https://sui-facilitator.onrender.com.

Both follow the existing entry format and link to primary documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

