### PR TITLE
Add move-test-gen to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
 - [DryRunTransactionBlockResponsePlus](https://github.com/SuiSec/DryRunTransactionBlockResponsePlus) - Decorator of `DryRunTransactionBlockResponse`, highlight `SenderChange`.
 - [Guardians](https://github.com/suiet/guardians) - Phishing Website Protection.
 - [HoneyPotDetectionOnSui](https://github.com/SuiSec/HoneyPotDetectionOnSui) - Detect HoneyPot SCAM on Sui.
+- [move-test-gen](https://github.com/mehvetero/move-test-gen) - Agent skill that generates edge-case test suites (boundary, arithmetic, access-control, economic) for Sui Move functions.
 
 ## AI
 - [Talus](https://docs.talus.network/) - Build autonomous digital economy powered by Sui.


### PR DESCRIPTION
Adds [move-test-gen](https://github.com/mehvetero/move-test-gen) to the Security section.

It is an agent skill (following the [agentskills spec](https://github.com/agentskills/agentskills)) that generates edge-case test suites for Sui Move functions — boundary values, arithmetic overflow, access control violations, state machine ordering, and economic attack patterns like fee evasion and share inflation.

The examples directory contains a complete Sui package (Move.toml + sources + tests) that passes `sui move test` with 21/21 tests on CLI v1.37.3.

I believe it fits the Security section because its purpose is catching vulnerability patterns in Move code through systematic test generation.