### PR TITLE
Add Testnet Faucets to the Faucets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,3 +260,4 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
 - SuiwareFaucetBot - Sui Faucet Bot for Telegram.
   - [GitHub](https://github.com/suiware/SuiwareFaucetBot) - [Telegram Bot](https://t.me/SuiwareFaucetBot)
 - [Suiware Faucet Chrome Extension](https://github.com/suiware/suiware-faucet-extension) - An experimental Chrome extension for receiving devnet and testnet SUI.
+- [Testnet Faucets](https://testnetfaucets.dev) - Directory of Sui and 40+ other network testnet faucets, health-checked daily and verified on-chain. Free JSON API.


### PR DESCRIPTION
Adds [Testnet Faucets](https://testnetfaucets.dev) to the `## Faucets` section — a live directory of blockchain testnet faucets across 40+ networks including Sui, health-checked daily and verified on-chain by reading each dispensing wallet's live balance and payout history. It also exposes a free JSON API and a CI preflight tool, so Sui developers can find working faucets and script availability checks. Formatted to match the existing faucet entries and appended at the end of the section.