### PR TITLE
Add OpenChainBench — live Sui RPC latency benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
 
 - RPC Tools (Polymedia) - A webapp that lets users find the fastest RPC for their location.
   - [GitHub](https://github.com/juzybits/polymedia-rpcs) - [Documentation](https://rpcs.polymedia.app/)
+- [OpenChainBench](https://openchainbench.com/benchmarks/sui-rpc) — Live latency benchmark for Sui RPC providers (Mysten Labs, PublicNode, BlockVision, Suiet, OnFinality): p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.
 - [Polymedia Commando (Polymedia)](https://github.com/juzybits/polymedia-commando) - Sui command line tools to help with Sui airdrops (send coins to many addresses), gather data from different sources (Sui RPCs, Indexer.xyz, Suiscan), and more.
 - [YubiSui (MystenLabs)](https://github.com/MystenLabs/yubigen) - Create a Sui Wallet inside a yubikey and sign Sui transactions with it.
 - [`sui-dapp-kit-theme-creator`](https://sui-dapp-kit-theme-creator.app/) - Build custom Sui dApp Kit themes.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Sui is the first Blockchain built for internet scale, enabling fast, scalable, a
 
 - RPC Tools (Polymedia) - A webapp that lets users find the fastest RPC for their location.
   - [GitHub](https://github.com/juzybits/polymedia-rpcs) - [Documentation](https://rpcs.polymedia.app/)
-- [OpenChainBench](https://openchainbench.com/benchmarks/sui-rpc) — Live latency benchmark for Sui RPC providers (Mysten Labs, PublicNode, BlockVision, Suiet, OnFinality): p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.
+- [OpenChainBench](https://openchainbench.com/benchmarks/sui-rpc) - Live latency benchmark for Sui RPC providers (Mysten Labs, PublicNode, BlockVision, Suiet, OnFinality): p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.
 - [Polymedia Commando (Polymedia)](https://github.com/juzybits/polymedia-commando) - Sui command line tools to help with Sui airdrops (send coins to many addresses), gather data from different sources (Sui RPCs, Indexer.xyz, Suiscan), and more.
 - [YubiSui (MystenLabs)](https://github.com/MystenLabs/yubigen) - Create a Sui Wallet inside a yubikey and sign Sui transactions with it.
 - [`sui-dapp-kit-theme-creator`](https://sui-dapp-kit-theme-creator.app/) - Build custom Sui dApp Kit themes.


### PR DESCRIPTION
Adds [OpenChainBench](https://openchainbench.com/benchmarks/sui-rpc) to the Misc section alongside the existing RPC Tools (Polymedia) entry, since both tools address RPC endpoint performance for Sui developers.

**What it does:** Continuously probes Sui RPC providers (Mysten Labs, PublicNode, BlockVision, Suiet, OnFinality) from US-East, EU-West and Singapore every 60 seconds and publishes p50/p90/p99 latency rankings. Developers can use it to pick the fastest public node for their region.

**Why it fits here:** The existing RPC Tools (Polymedia) entry lets users find the fastest RPC interactively. OpenChainBench is the continuous monitoring complement — same audience, same problem, different approach (live global leaderboard vs. on-demand browser test).

Open source: https://github.com/ChainBench/OpenChainBench